### PR TITLE
add header file declear in syscall.c

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,13 @@
         "synch.h": "c",
         "vaddr.h": "c",
         "palloc.h": "c",
-        "off_t.h": "c"
+        "off_t.h": "c",
+        "unistd.h": "c",
+        "loader.h": "c",
+        "syscall-nr.h": "c",
+        "inode.h": "c",
+        "file.h": "c",
+        "filesys.h": "c"
     },
     "C_Cpp.errorSquiggles": "disabled"
 }

--- a/filesys/file.c
+++ b/filesys/file.c
@@ -51,6 +51,12 @@ file_duplicate (struct file *file) {
 /* Closes FILE. */
 void
 file_close (struct file *file) {
+	// printf("왜안돼\n");
+	// printf("file address is: %p\n", file);
+	// printf("close file i_node = %p\n", file->inode);
+	// printf("close file pos = %d\n", file->pos);
+	// printf("close file deny_write = %d\n", file->deny_write);
+	// printf("야발 ^^ \n\n\n");
 	if (file != NULL) {
 		file_allow_write (file);
 		inode_close (file->inode);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -8,6 +8,7 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "user/syscall.h"
+#include "filesys/filesys.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -219,7 +220,8 @@ sys_tell (int fd) {
 
 void
 sys_close (int fd) {
-	file_close(return_file(fd));	
+	struct file *close_file = return_file(fd);
+	file_close(close_file);	
 	struct thread *t = thread_current();
 	t->fdt[fd] = NULL;
 	if(fd < t->next_fd)
@@ -319,7 +321,6 @@ syscall_handler (struct intr_frame *f UNUSED) {
 
 
 		case SYS_CLOSE:
-
             sys_close(f->R.rdi);
 			return;
 


### PR DESCRIPTION
syscall.c 에 file_sys 가 선언 되지않아 file_sys의 함수들을 잘못 참조하여 의미없는 값들을 다루는 문제 해결